### PR TITLE
fix: error when trying to pull exechealthz image for health and readiness probes

### DIFF
--- a/charts/unbound/templates/deployment.yaml
+++ b/charts/unbound/templates/deployment.yaml
@@ -64,18 +64,6 @@ spec:
         {{- with .Values.containers.unbound.args }}
         args: {{ toYaml . | nindent 10 }}
         {{- end }}
-      - name: "healthz"
-        image: {{ .Values.containers.healthz.image.repository }}:{{ .Values.containers.healthz.image.tag }}
-        imagePullPolicy: {{ .Values.containers.healthz.image.pullPolicy | quote }}
-        {{- with .Values.containers.healthz.resources }}
-        resources: {{ toYaml . | nindent 10 }}
-        {{- end }}
-        args:
-          - "-cmd=nslookup health.check.unbound. 127.0.0.1:{{ .Values.containers.unbound.serverPort }} > /dev/null"
-        ports:
-        - name: healthz
-          containerPort: 8080
-          protocol: TCP
       {{- if .Values.metrics.enabled }}
       - name: "exporter"
         image: {{ .Values.containers.exporter.image.repository }}:{{ .Values.containers.exporter.image.tag }}

--- a/charts/unbound/values.yaml
+++ b/charts/unbound/values.yaml
@@ -58,15 +58,6 @@ containers:
       # - name: "fake3.host.net"
       #   ip: "10.12.10.10"
 
-  healthz:
-    image:
-      repository: gcr.io/google-containers/exechealthz
-      tag: "1.2"
-      pullPolicy: IfNotPresent
-    resources:
-      requests:
-        cpu: 2m
-        memory: 10Mi
   exporter:
     image:
       repository: tombokombo/unbound-exporter
@@ -84,18 +75,22 @@ strategy:
     maxUnavailable: 1
 
 livenessProbe:
-  httpGet:
-    path: "/healthz"
-    port: 8080
+  exec:
+    command:
+    - nslookup
+    - health.check.unbound.
+    - 127.0.0.1:53
   initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 10
   failureThreshold: 10
 
 readinessProbe:
-  httpGet:
-    path: "/healthz"
-    port: 8080
+  exec:
+    command:
+    - nslookup
+    - health.check.unbound.
+    - 127.0.0.1:53
   initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 10

--- a/charts/unbound/values.yaml
+++ b/charts/unbound/values.yaml
@@ -79,7 +79,7 @@ livenessProbe:
     command:
     - nslookup
     - health.check.unbound.
-    - 127.0.0.1:53
+    - 127.0.0.1
   initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 10
@@ -90,7 +90,7 @@ readinessProbe:
     command:
     - nslookup
     - health.check.unbound.
-    - 127.0.0.1:53
+    - 127.0.0.1
   initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 10


### PR DESCRIPTION
fixes https://github.com/pixelfederation/unbound/issues/20

i removed the health sidecar, and changed the default health and readiness probe values to use `exec`.
maybe they should just be hard-coded in the `deployment.yaml`?